### PR TITLE
Automatic bundling libmecab

### DIFF
--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -69,7 +69,11 @@ def mecab_config_linux_build():
         os.symlink(".libs/libmecab.so", "libmecab.so")
         os.chdir(base_dir)
         data_files = [(lib_dir, glob.glob(src_dir + "/.libs/libmecab.*"))]
-    mecab_details = (src_dir, src_dir, 'mecab stdc++', '-Wl,-rpath={}'.format(lib_dir))
+    if platform.platform().startswith("Darwin"):
+        lib_arg = "-rpath {}".format(lib_dir)
+    else:
+        lib_arg = "-Wl,-rpath={}".format(lib_dir)
+    mecab_details = (src_dir, src_dir, 'mecab stdc++', lib_arg)
     return mecab_details, data_files
 
 def check_libmecab():

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -82,8 +82,8 @@ def check_libmecab():
             mecab_config_windows,
             mecab_config,
             mecab_config_cygwin,
-            mecab_config_debian,
-            mecab_config_debian2,
+            mecab_config_debian_root,
+            mecab_config_debian_user,
             mecab_config_linux_build,
             ]
 

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -43,13 +43,14 @@ def mecab_config_debian2():
     mc,dummy = mecab_config("usr/bin/mecab-config")
     os.chdir(base_dir)
     lib_dir = site.USER_BASE + "/lib/mecab"
-    mecab_details = (mc[0].replace("/usr/","build/mecab/usr/"), mc[1].replace("/usr/","build/mecab/usr/"), mc[2], '-Wl,-rpath={}'.format(lib_dir))
-    data_files = [(lib_dir, glob.glob(mc[1].replace("/usr/","build/mecab/usr/") + "/libmecab.*"))]
+    mecab_details = ("build/mecab" + mc[0], "build/mecab" + mc[1], mc[2], '-Wl,-rpath={}'.format(lib_dir))
+    data_files = [(lib_dir, glob.glob("build/mecab" + mc[1] + "/libmecab.*"))]
     return mecab_details, data_files
 
 def mecab_config_linux_build():
     # this builds mecab from source on a linux-like (OSX?)
     # XXX what platform is this for?
+    base_dir = os.getcwd()
     os.chdir("build/mecab")
     subprocess.run(["git", "clone", "--depth=1", "https://github.com/taku910/mecab"])
     os.chdir("mecab/mecab")
@@ -60,12 +61,17 @@ def mecab_config_linux_build():
         subprocess.run(["./configure", "--disable-static", "--enable-shared", "--with-charset=utf8"])
     os.chdir("src")
     subprocess.run(["make", "libmecab.la"])
-    if not os.path.isfile("libmecab.so"):
-        os.symlink(".libs/libmecab.so", "libmecab.so")
     src_dir = "build/mecab/mecab/mecab/src"
-    obj= " ".join(glob.glob(".libs/*.o")).replace(".libs/", src_dir+"/.libs/")
-    mecab_details = (src_dir, '', 'stdc++', obj)
-    return mecab_details, []
+    lib_dir = site.USER_BASE + "/lib/mecab"
+    if os.path.isfile("libmecab.so"):
+        os.chdir(base_dir)
+        data_files = [(lib_dir, glob.glob(src_dir + "/libmecab.*"))]
+    else:
+        os.symlink(".libs/libmecab.so", "libmecab.so")
+        os.chdir(base_dir)
+        data_files = [(lib_dir, glob.glob(src_dir + "/.libs/libmecab.*"))]
+    mecab_details = (src_dir, src_dir, 'mecab stdc++', '-Wl,-rpath={}'.format(lib_dir))
+    return mecab_details, data_files
 
 def check_libmecab():
     """Get MeCab build parameters.

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -8,31 +8,32 @@ def mecab_config(com="mecab-config"):
     output = subprocess.check_output([com, "--inc-dir", "--libs-only-L", "--libs-only-l"])
     if not isinstance(output, str):
         output = output.decode("utf-8")
-    return output
+    return output.split('\n'), []
 
-def check_libmecab():
+def mecab_config_windows():
+    ## Windows
     if os.name == 'nt':
         win_mecab_dir = r'C:\mecab'
-        return win_mecab_dir+"\n"+win_mecab_dir+"\nlibmecab\n", [("lib\\site-packages\\", ["{}\\libmecab.dll".format(win_bin_dir)])]
+        mecab_details = (win_mecab_dir, win_mecab_dir, 'libmecab')
+        data_files = [("lib\\site-packages\\", ["{}\\libmecab.dll".format(win_bin_dir)])]
+        return mecab_details, data_files
 
-    try:
-        output = mecab_config()
-        return output, []
-    except:
-        pass
-
+def mecab_config_cygwin():
     base_dir = os.getcwd()
     os.makedirs("build/mecab", exist_ok=True)
     os.chdir("build/mecab")
-
+    ## Cygwin
     if platform.system().startswith("CYGWIN"):
-        rep = "mecab-cygwin64" if platform.machine()=="x86_64" else "mecab-cygwin32"
+        rep = "mecab-cygwin64" if platform.machine() == "x86_64" else "mecab-cygwin32"
         subprocess.run(["git", "clone", "--depth=1", "https://github.com/KoichiYasuoka/"+rep])
         os.chdir(rep)
         subprocess.run(["sh", "-x", "./install.sh", "/usr/local"])
         output = mecab_config("/usr/local/bin/mecab-config")
         return output, []
 
+def mecab_config_debian():
+    ## Debian
+    # XXX how is this different from the debian2 part?
     try:
         subprocess.run(["apt-get", "install", "-y", "libmecab-dev"])
         output = mecab_config("mecab-config")
@@ -40,6 +41,11 @@ def check_libmecab():
     except:
         pass
 
+def mecab_config_debian2():
+    ##XXX What platform is this? Also Debian?
+    os.chdir(base_dir+"/build/mecab")
+    subprocess.run(["git", "clone", "--depth=1", "https://github.com/taku910/mecab"])
+    os.chdir("mecab/mecab")
     try:
         subprocess.run(["apt-get", "download", "libmecab-dev", "libmecab2"])
         for deb in glob.glob("libmecab*.deb"):
@@ -47,11 +53,16 @@ def check_libmecab():
         output = mecab_config("usr/bin/mecab-config").replace("/usr/","build/mecab/usr/")
         os.chdir(base_dir)
         mc = output.split("\n")
-        lib_dir = site.USER_BASE+"/lib/mecab"
-        return output+"\n-Wl,-rpath="+lib_dir, [(lib_dir, glob.glob(mc[1]+"/libmecab.*"))]
+        lib_dir = site.USER_BASE + "/lib/mecab"
+        mecab_details = (*mc, '-Wl,-rpath={}'.format(lib_dir))
+        data_files = [(lib_dir, glob.glob(mc[1] + "/libmecab.*"))]
+        return mecab_details, data_files
     except:
         pass
 
+def mecab_config_linux_build():
+    # this builds mecab from source on a linux-like (OSX?)
+    # XXX what platform is this for?
     os.chdir(base_dir+"/build/mecab")
     subprocess.run(["git", "clone", "--depth=1", "https://github.com/taku910/mecab"])
     os.chdir("mecab/mecab")
@@ -64,6 +75,36 @@ def check_libmecab():
     subprocess.run(["make", "libmecab.la"])
     if not os.path.isfile("libmecab.so"):
         os.symlink(".libs/libmecab.so", "libmecab.so")
-    src_dir="build/mecab/mecab/mecab/src"
-    obj=" ".join(glob.glob(".libs/*.o")).replace(".libs/", src_dir+"/.libs/")
-    return src_dir+"\n\nstdc++\n"+obj, []
+    src_dir = "build/mecab/mecab/mecab/src"
+    obj= " ".join(glob.glob(".libs/*.o")).replace(".libs/", src_dir+"/.libs/")
+    mecab_details = (src_dir, '', 'stdc++', obj)
+    return mecab_details, []
+
+def check_libmecab():
+    """Get MeCab build parameters.
+
+    Where available the mecab-config script is used, but if it's available it
+    will be installed or the parameters will otherwise be figured out."""
+
+    configs = [
+            mecab_config_windows,
+            mecab_config,
+            mecab_config_cygwin,
+            mecab_config_debian,
+            mecab_config_debian2,
+            mecab_config_linux_build,
+            ]
+
+    # A few scripts will use a build directory. Save where we start so we can
+    # reset the directory after each build step.
+    cwd = os.getcwd()
+    for config in configs:
+        try:
+            out = config()
+            if out:
+                return out
+        except:
+            # failure is normal, typically just a different platform
+            pass
+        finally:
+            os.chdir(cwd)

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -3,11 +3,22 @@ import platform
 import subprocess
 import glob
 
+def mecab_config(com="mecab-config"):
+    output = subprocess.check_output([com, "--inc-dir", "--libs-only-L", "--libs-only-l"])
+    if not isinstance(output, str):
+        output = output.decode("utf-8")
+    return output
+
 def check_libmecab():
     try:
-        output = subprocess.check_output(["mecab-config", "--inc-dir", "--libs-only-L", "--libs-only-l"])
-        if not isinstance(output, str):
-            output = output.decode("utf-8")
+        output = mecab_config()
+        return output
+    except:
+        pass
+
+    try:
+        subprocess.run(["apt-get", "install", "-y", "libmecab-dev"])
+        output = mecab_config()
         return output
     except:
         pass
@@ -15,13 +26,16 @@ def check_libmecab():
     os.makedirs("build/mecab", exist_ok=True)
     os.chdir("build/mecab")
 
+    if platform.system().startswith("CYGWIN"):
+        rep = "mecab-cygwin64" if platform.machine()=="x86_64" else "mecab-cygwin32"
+        subprocess.run(["git", "clone", "--depth=1", "https://github.com/KoichiYasuoka/"+rep])
+        output = mecab_config(rep+"/bin/mecab-config")
+        return output.replace("/usr/local/", "build/mecab/"+rep+"/")
     try:
         subprocess.run(["apt-get", "download", "libmecab-dev", "libmecab2"])
         for deb in glob.glob("libmecab*.deb"):
             subprocess.run(["dpkg", "-x", deb, "."])
-        output = subprocess.check_output(["./usr/bin/mecab-config", "--inc-dir", "--libs-only-L", "--libs-only-l"])
-        if not isinstance(output, str):
-            output = output.decode("utf-8")
+        output = mecab_config("usr/bin/mecab-config")
         return output.replace("/usr/","build/mecab/usr/")
     except:
         pass

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -44,7 +44,7 @@ def mecab_config_debian2():
     os.chdir(base_dir)
     lib_dir = site.USER_BASE + "/lib/mecab"
     mecab_details = (mc[0].replace("/usr/","build/mecab/usr/"), mc[1].replace("/usr/","build/mecab/usr/"), mc[2], '-Wl,-rpath={}'.format(lib_dir))
-    data_files = [(lib_dir, glob.glob(mc[1] + "/libmecab.*"))]
+    data_files = [(lib_dir, glob.glob(mc[1].replace("/usr/","build/mecab/usr/") + "/libmecab.*"))]
     return mecab_details, data_files
 
 def mecab_config_linux_build():

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -12,7 +12,7 @@ def mecab_config(com="mecab-config"):
 def check_libmecab():
     if os.name == 'nt':
         win_mecab_dir = r'C:\mecab'
-        return win_mecab_dir+"\n"+win_mecab_dir+"\nlibmecab", [("lib\\site-packages\\", ["{}\\libmecab.dll".format(win_bin_dir)])]
+        return win_mecab_dir+"\n"+win_mecab_dir+"\nlibmecab\n", [("lib\\site-packages\\", ["{}\\libmecab.dll".format(win_bin_dir)])]
 
     try:
         output = mecab_config()
@@ -20,7 +20,6 @@ def check_libmecab():
     except:
         pass
 
-    base_dir = os.getcwd()
     os.makedirs("build/mecab", exist_ok=True)
     os.chdir("build/mecab")
 
@@ -33,30 +32,23 @@ def check_libmecab():
         return output, []
 
     try:
-        subprocess.run(["apt-get", "download", "libmecab-dev", "libmecab2"])
-        for deb in glob.glob("libmecab*.deb"):
-            subprocess.run(["dpkg", "-x", deb, "."])
-        output = mecab_config("usr/bin/mecab-config").replace("/usr/","build/mecab/usr/")
-        os.chdir(base_dir)
-        d = output.split("\n")
-        return output, [(".", glob.glob(d[1]+"/libmecab.*"))]
+        subprocess.run(["apt-get", "install", "-y", "libmecab-dev"])
+        output = mecab_config("mecab-config")
+        return output, []
     except:
         pass
 
-    os.chdir(base_dir+"/build/mecab")
     subprocess.run(["git", "clone", "--depth=1", "https://github.com/taku910/mecab"])
     os.chdir("mecab/mecab")
     if not os.path.isfile("mecab-config"):
         for f in ["aclocal.m4", "config.h.in", "configure", "Makefile.in", "src/Makefile.in"]:
             subprocess.run(["touch", f])
             subprocess.run(["sleep", "1"])
-        subprocess.run(["./configure", "--enable-static", "--enable-shared", "--with-charset=utf8"])
+        subprocess.run(["./configure", "--disable-static", "--enable-shared", "--with-charset=utf8"])
     os.chdir("src")
     subprocess.run(["make", "libmecab.la"])
-    if not os.path.isfile("libmecab.a"):
-        os.symlink(".libs/libmecab.a", "libmecab.a")
     if not os.path.isfile("libmecab.so"):
         os.symlink(".libs/libmecab.so", "libmecab.so")
-    os.chdir(base_dir)
     src_dir="build/mecab/mecab/mecab/src"
-    return src_dir+"\n"+src_dir+"\nmecab stdc++", [(".", glob.glob(src_dir+"/libmecab.*"))]
+    obj=" ".join(glob.glob(".libs/*.o")).replace(".libs/",src_dir+"/.libs/")
+    return src_dir+"\n\nstdc++\n"+obj, []

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -27,13 +27,13 @@ def mecab_config_cygwin():
         mecab_details = ("build/mecab/"+rep+"/include", "build/mecab/"+rep+"/lib", "mecab stdc++")
         return mecab_details, []
 
-def mecab_config_debian():
+def mecab_config_debian_root():
     ## Debian (as root)
     subprocess.run(["apt-get", "install", "-y", "libmecab-dev"])
     output = mecab_config("mecab-config")
     return output
 
-def mecab_config_debian2():
+def mecab_config_debian_user():
     ## Debian (as user)
     base_dir = os.getcwd()
     os.chdir("build/mecab")
@@ -48,8 +48,7 @@ def mecab_config_debian2():
     return mecab_details, data_files
 
 def mecab_config_linux_build():
-    # this builds mecab from source on a linux-like (OSX?)
-    # XXX what platform is this for?
+    """Build from source on Linux-like as a last resort."""
     base_dir = os.getcwd()
     os.chdir("build/mecab")
     subprocess.run(["git", "clone", "--depth=1", "https://github.com/taku910/mecab"])

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -41,11 +41,9 @@ def mecab_config_debian2():
     for deb in glob.glob("libmecab*.deb"):
         subprocess.run(["dpkg", "-x", deb, "."])
     mc,dummy = mecab_config("usr/bin/mecab-config")
-    print(mc)
     os.chdir(base_dir)
     lib_dir = site.USER_BASE + "/lib/mecab"
     mecab_details = (mc[0].replace("/usr/","build/mecab/usr/"), mc[1].replace("/usr/","build/mecab/usr/"), mc[2], '-Wl,-rpath={}'.format(lib_dir))
-    print(mecab_details)
     data_files = [(lib_dir, glob.glob(mc[1] + "/libmecab.*"))]
     return mecab_details, data_files
 

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -1,0 +1,42 @@
+import os
+import platform
+import subprocess
+import glob
+
+def check_libmecab():
+    try:
+        output = subprocess.check_output(["mecab-config", "--inc-dir", "--libs-only-L", "--libs-only-l"])
+        if not isinstance(output, str):
+            output = output.decode("utf-8")
+        return output
+    except:
+        pass
+
+    os.makedirs("build/mecab", exist_ok=True)
+    os.chdir("build/mecab")
+
+    try:
+        subprocess.run(["apt-get", "download", "libmecab-dev", "libmecab2"])
+        for deb in glob.glob("libmecab*.deb"):
+            subprocess.run(["dpkg", "-x", deb, "."])
+        output = subprocess.check_output(["./usr/bin/mecab-config", "--inc-dir", "--libs-only-L", "--libs-only-l"])
+        if not isinstance(output, str):
+            output = output.decode("utf-8")
+        return output.replace("/usr/","build/mecab/usr/")
+    except:
+        pass
+
+    subprocess.run(["git", "clone", "--depth=1", "https://github.com/taku910/mecab"])
+    os.chdir("mecab/mecab")
+    if not os.path.isfile("mecab-config"):
+        for f in ["aclocal.m4", "config.h.in", "configure", "Makefile.in", "src/Makefile.in"]:
+            subprocess.run(["touch", f])
+            subprocess.run(["sleep", "1"])
+        subprocess.run(["./configure", "--enable-static", "--enable-shared", "--with-charset=utf8"])
+    os.chdir("src")
+    subprocess.run(["make", "libmecab.la"])
+    if not os.path.isfile("libmecab.a"):
+        os.symlink(".libs/libmecab.a", "libmecab.a")
+    if not os.path.isfile("libmecab.so"):
+        os.symlink(".libs/libmecab.so", "libmecab.so")
+    return "build/mecab/mecab/mecab/src\nbuild/mecab/mecab/mecab/src\nmecab stdc++"

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,16 @@
 import pathlib
 import setuptools
 import subprocess
-import os
 from distutils.core import setup
 from distutils.extension import Extension
 
 from fugashi_util import check_libmecab
-curdir = os.getcwd()
-output,data_files = check_libmecab()
-os.chdir(curdir)
-mecab_config = (output+"\n\n\n\n").split("\n")
+
+# get the build parameters
+output, data_files = check_libmecab()
+
+# pad the list in case something's missing
+mecab_config = list(output) + ([''] * 5)
 include_dirs = mecab_config[0].split()
 library_dirs = mecab_config[1].split()
 libraries = mecab_config[2].split()

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,14 @@ mecab_config = output.split("\n")
 include_dirs = mecab_config[0].split()
 library_dirs = mecab_config[1].split()
 libraries = mecab_config[2].split()
+extra_objects = mecab_config[3].split()
 
 extensions = Extension('fugashi', 
         ['fugashi/fugashi.pyx'], 
         libraries=libraries,
         library_dirs=library_dirs,
-        include_dirs=include_dirs)
+        include_dirs=include_dirs,
+        extra_objects=extra_objects)
 
 setup(name='fugashi', 
       version='0.1.6',

--- a/setup.py
+++ b/setup.py
@@ -22,17 +22,13 @@ if is_windows:
     libraries = ["libmecab"]
     data_files = [("lib\\site-packages\\", ["{}\\libmecab.dll".format(win_bin_dir)])]
 else:
-    try:
-        output = subprocess.check_output(["mecab-config", "--inc-dir", "--libs-only-L", "--libs-only-l"])
-    except:
-	from .util import download_libmecab
-	output = download_libmecab()
-    if not isinstance(output, str):
-	output = output.decode("utf-8")
-    output = output.split("\n")
-    include_dirs = output[0].split()
-    library_dirs = output[1].split()
-    libraries = output[2].split()
+    from fugashi_util import check_libmecab
+    curdir = os.getcwd()
+    mecab_config = check_libmecab().split("\n")
+    os.chdir(curdir)
+    include_dirs = mecab_config[0].split()
+    library_dirs = mecab_config[1].split()
+    libraries = mecab_config[2].split()
     data_files = []
 
 extensions = Extension('fugashi', 

--- a/setup.py
+++ b/setup.py
@@ -5,31 +5,14 @@ import os
 from distutils.core import setup
 from distutils.extension import Extension
 
-is_windows = os.name == 'nt'
-
-win_mecab_dir = r'C:\mecab'
-win_sdk_dir = win_mecab_dir
-win_bin_dir = win_mecab_dir
-# If you want to use official Windows binary, you can comment out following variables
-#is_64bits = sys.maxsize > 2**32
-#win_mecab_dir = r'C:\Program Files{}\MeCab'.format('' if is_64bits else ' (x86)')
-#win_sdk_dir = r'{}\sdk'.format(win_mecab_dir)
-#win_bin_dir = r'{}\bin'.format(win_mecab_dir)
-
-if is_windows:
-    include_dirs = [win_sdk_dir]
-    library_dirs = [win_sdk_dir]
-    libraries = ["libmecab"]
-    data_files = [("lib\\site-packages\\", ["{}\\libmecab.dll".format(win_bin_dir)])]
-else:
-    from fugashi_util import check_libmecab
-    curdir = os.getcwd()
-    mecab_config = check_libmecab().split("\n")
-    os.chdir(curdir)
-    include_dirs = mecab_config[0].split()
-    library_dirs = mecab_config[1].split()
-    libraries = mecab_config[2].split()
-    data_files = []
+from fugashi_util import check_libmecab
+curdir = os.getcwd()
+output,data_files = check_libmecab()
+os.chdir(curdir)
+mecab_config = output.split("\n")
+include_dirs = mecab_config[0].split()
+library_dirs = mecab_config[1].split()
+libraries = mecab_config[2].split()
 
 extensions = Extension('fugashi', 
         ['fugashi/fugashi.pyx'], 

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,6 @@ import os
 from distutils.core import setup
 from distutils.extension import Extension
 
-def mecab_config(arg):
-	output = subprocess.check_output(["mecab-config", arg])
-
-	if not isinstance(output, str):
-		output = output.decode("utf-8")
-
-	return output.split()
-
 is_windows = os.name == 'nt'
 
 win_mecab_dir = r'C:\mecab'
@@ -30,9 +22,17 @@ if is_windows:
     libraries = ["libmecab"]
     data_files = [("lib\\site-packages\\", ["{}\\libmecab.dll".format(win_bin_dir)])]
 else:
-    include_dirs = mecab_config("--inc-dir")
-    library_dirs = mecab_config("--libs-only-L")
-    libraries = mecab_config("--libs-only-l")
+    try:
+        output = subprocess.check_output(["mecab-config", "--inc-dir", "--libs-only-L", "--libs-only-l"])
+    except:
+	from .util import download_libmecab
+	output = download_libmecab()
+    if not isinstance(output, str):
+	output = output.decode("utf-8")
+    output = output.split("\n")
+    include_dirs = output[0].split()
+    library_dirs = output[1].split()
+    libraries = output[2].split()
     data_files = []
 
 extensions = Extension('fugashi', 

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,20 @@ from fugashi_util import check_libmecab
 curdir = os.getcwd()
 output,data_files = check_libmecab()
 os.chdir(curdir)
-mecab_config = output.split("\n")
+mecab_config = (output+"\n\n\n\n").split("\n")
 include_dirs = mecab_config[0].split()
 library_dirs = mecab_config[1].split()
 libraries = mecab_config[2].split()
 extra_objects = mecab_config[3].split()
+extra_link_args = mecab_config[4].split()
 
 extensions = Extension('fugashi', 
         ['fugashi/fugashi.pyx'], 
         libraries=libraries,
         library_dirs=library_dirs,
         include_dirs=include_dirs,
-        extra_objects=extra_objects)
+        extra_objects=extra_objects,
+        extra_link_args=extra_link_args)
 
 setup(name='fugashi', 
       version='0.1.6',


### PR DESCRIPTION
For the environments without `mecab-config` (#7) I've tentatively written several approachs to automatic bundle of libmecab. Debian, Ubuntu, Cygwin, and Jupyter (Google Colab.) could install `fugashi` without `mecab-config`.