### PR TITLE
Get 3.10 build working for MacOS

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -12,23 +12,23 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         include:
-          - python-version: 3.6
-            py-short: 36
-            py-short2: 36m
-          - python-version: 3.7
-            py-short: 37
-            py-short2: 37m
-          - python-version: 3.8
-            py-short: 38
-            py-short2: 38
-          - python-version: 3.9
-            py-short: 39
-            py-short2: 39
-          - python-version: 3.10
-            py-short: 310
-            py-short2: 310
+          - python-version: '3.6'
+            py-short: '36'
+            py-short2: '36m'
+          - python-version: '3.7'
+            py-short: '37'
+            py-short2: '37m'
+          - python-version: '3.8'
+            py-short: '38'
+            py-short2: '38'
+          - python-version: '3.9'
+            py-short: '39'
+            py-short2: '39'
+          - python-version: '3.10'
+            py-short: '310'
+            py-short2: '310'
     steps:
     - uses: actions/checkout@v1
     - name: Set up python


### PR DESCRIPTION
Issues in the GitHub Actions build seem to be due to YAML syntax interpreting 3.10 as a Fixnum rather than a String.

This has successfully run and generated a working MacOS Python 3.10 build on my fork: https://github.com/lambdadog/fugashi/actions/runs/1603167369

Of note is that I've gone ahead and put all of the `python-version`-related data in single quotes, as a significant amount of it was getting parsed as Fixnums, and while it wasn't causing any issues other than for `3.10` coming out as `3.1`, having single-quotes be the convention ensures correctness in the future.