### PR TITLE
Get 3.10 build working for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,23 +13,23 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         include:
-          - python-version: 3.6
-            py-short: 36
-            py-short2: 36m
-          - python-version: 3.7
-            py-short: 37
-            py-short2: 37m
-          - python-version: 3.8
-            py-short: 38
-            py-short2: 38
-          - python-version: 3.9
-            py-short: 39
-            py-short2: 39
-          - python-version: 3.10
-            py-short: 310
-            py-short2: 310
+          - python-version: '3.6'
+            py-short: '36'
+            py-short2: '36m'
+          - python-version: '3.7'
+            py-short: '37'
+            py-short2: '37m'
+          - python-version: '3.8'
+            py-short: '38'
+            py-short2: '38'
+          - python-version: '3.9'
+            py-short: '39'
+            py-short2: '39'
+          - python-version: '3.10'
+            py-short: '310'
+            py-short2: '310'
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
   build_windows:
     runs-on: windows-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         include:


### PR DESCRIPTION
Essentially the same changes as #50 other than bumping `max-parallel` to 5.

Willing to revert that if there's some underlying reason for a `max-parallel` of 4, but after hunting through the GitHub Actions docs for a bit I couldn't find any particular rate limits on Windows or anything like that so I assumed it was just left over from when there were less Python versions you were supporting.

Successful run: https://github.com/lambdadog/fugashi/actions/runs/1603245750 (doesn't include the `max-parallel` bump from 4->5, but there should be no difference there other than 5 running at a time rather than 4, and I couldn't be bothered to engineer a way to start another run)

---

Will close #44 once builds are pushed to Pypi.