### PR TITLE
Fix tests on manylinux2014

### DIFF
--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -31,4 +31,4 @@ jobs:
     - uses: actions/checkout@v1
     - run: docker build -t fugashi .
     - name: setup and test
-      run: docker run -v $(pwd):/workdir -w /workdir fugashi sh -c "$PYTHON -m pip install cython pytest wheel unidic-lite ipadic && $PYTHON -m pip install -e . && $PYTHON -m pytest"
+      run: docker run -v $(pwd):/workdir -w /workdir fugashi sh -c "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/ && $PYTHON -m pip install cython pytest wheel unidic-lite ipadic && $PYTHON -m pip install -e . && $PYTHON -m pytest"

--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -8,9 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        include:
+          - python-version: '3.6'
+            py-short: '36'
+            py-short2: '36m'
+          - python-version: '3.7'
+            py-short: '37'
+            py-short2: '37m'
+          - python-version: '3.8'
+            py-short: '38'
+            py-short2: '38'
+          - python-version: '3.9'
+            py-short: '39'
+            py-short2: '39'
+          - python-version: '3.10'
+            py-short: '310'
+            py-short2: '310'
     env:
-      PYTHON: python${{ matrix.python-version }}
+      PYTHON: /opt/python/cp${{ matrix.py-short }}-cp${{ matrix.py-short2 }}/bin/python
     steps:
     - uses: actions/checkout@v1
     - run: docker build -t fugashi .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM quay.io/pypa/manylinux2014_x86_64
-ENV PATH /root/.local/bin:/opt/python/cp36-cp36m/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/rh/devtoolset-2/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python/cp36-cp36m/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39:/opt/python/cp310-cp310
 
 RUN git clone --depth=1 https://github.com/taku910/mecab.git && \
     cd mecab/mecab && \


### PR DESCRIPTION
To do this, I've adjusted the methodology of `test_manylinux` to that of the manylinux builds a little, citing [`entrypoint.sh`](https://github.com/polm/fugashi/blob/9c698545b68ecb06281aed96fc27e0194f1f31c7/.github/workflows/entrypoint.sh).

Instead of setting the `PATH` in `Dockerfile` (which was causing the "no valid C compiler" errors) I've adjusted `test_manylinux.yaml` to use the same substitution methodology seen in `entrypoint.sh` to get the `python` executable irrespective of `PATH`. I also needed to add the [`LD_LIBRARY_PATH` hack](https://github.com/polm/fugashi/blob/9c698545b68ecb06281aed96fc27e0194f1f31c7/.github/workflows/entrypoint.sh#L21) in order for `libmecab.so` to be found.

This also means that the versions being tested for don't have to live both in `Dockerfile` AND in `test_manylinux.yaml`, which they did previously.

Working tests run: https://github.com/lambdadog/fugashi/actions/runs/1603485583

Overall, there are a couple of changes I'd still like to see here (caching of Mecab and sharing of resources between the manylinux builds and tests, most notably), but if I was going to do any CI refactors it would be to the entirety layout of the CI-relevant files so for now I intend to wait on my existing PRs being merged then hopefully dive into it all with a scalpel.

---

Closes #48 since manylinux2014 was already working for builds.