### PR TITLE
doc: better info for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ To get either of these dictionaries, you can install them directly using `pip`
 or do the below:
 
 ```sh
-pip install fugashi[unidic-lite]
+pip install 'fugashi[unidic-lite]'
 
 # The full version of UniDic requires a separate download step
-pip install fugashi[unidic]
+pip install 'fugashi[unidic]'
 python -m unidic download
 ```
 


### PR DESCRIPTION
for some env like `zsh` we need to add `'` in `pip` command
<img width="990" alt="image" src="https://github.com/polm/fugashi/assets/15976103/7b1efc72-8095-41e4-9ed7-377da09c6053">
