### PR TITLE
Return source white space string

### DIFF
--- a/fugashi/fugashi.pyx
+++ b/fugashi/fugashi.pyx
@@ -61,10 +61,6 @@ cdef class Node:
     @property
     def surface(self):
         if self._surface is None:
-            #self._surface = self.c_node.surface[:self.c_node.length].decode('utf-8')
-            #base = self._offset + (self.c_node.rlength - self.c_node.length)
-            #end = self._offset + self.c_node.rlength
-            #self._surface = self.__cstr[end - self.c_node.length:end].decode('utf-8')
             pass
         return self._surface
 

--- a/fugashi/fugashi.pyx
+++ b/fugashi/fugashi.pyx
@@ -113,7 +113,7 @@ cdef class Node:
         else:
             len = (self.rlength - self.length)
 
-            offset = self.c_node.prev.rlength
+            offset = self.c_node.prev.length
             end = offset + len
 
             return self.c_node.prev.surface[offset:end].decode("utf-8")

--- a/fugashi/fugashi.pyx
+++ b/fugashi/fugashi.pyx
@@ -111,7 +111,12 @@ cdef class Node:
         if self.length == self.rlength:
             return ''
         else:
-            return ' ' * (self.rlength - self.length)
+            len = (self.rlength - self.length)
+
+            offset = self.c_node.prev.rlength
+            end = offset + len
+
+            return self.c_node.prev.surface[offset:end].decode("utf-8")
         
     cdef list pad_none(self, list fields):
         try:

--- a/fugashi/tests/test_basic.py
+++ b/fugashi/tests/test_basic.py
@@ -28,11 +28,14 @@ ACCENT_TESTS = (
         ('稻村に行きました', ['0,2', '*', '0', '*', '*']),
         )
 
+# Last number is token index of white space
 WHITE_SPACE_TESTS = (
-        ("これは 半角スペースです", " "),
-        ("これは\tタブ文字です", "\t"),
-        ("これは\n改行文字です", "\n"),
-        ("これは\n\t 複数種類の空白文字です", "\n\t "),
+        ("これは 半角スペースです", " ", 2),
+        ("これは\tタブ文字です", "\t", 2),
+        ("これは\n改行文字です", "\n", 2),
+        ("これは\n\t 複数種類の空白文字です", "\n\t ", 2),
+        ("これは\n\t 複数種類の空白文字です", "\n\t ", 2),
+        ("\tタブ文字で始まる文字列", "\t", 0),
         )
 
 @pytest.mark.parametrize('text,wakati', WAKATI_TESTS)
@@ -94,9 +97,9 @@ def test_clobber():
 
     assert "a b c d".split() == [nn.surface for nn in nodes1]
 
-@pytest.mark.parametrize("text,space", WHITE_SPACE_TESTS)
-def test_white_space(text, space):
+@pytest.mark.parametrize("text,space,idx", WHITE_SPACE_TESTS)
+def test_white_space(text, space, idx):
     tagger = Tagger()
     nodes = tagger.parseToNodeList(text)
 
-    assert nodes[2].white_space == space
+    assert nodes[idx].white_space == space

--- a/fugashi/tests/test_basic.py
+++ b/fugashi/tests/test_basic.py
@@ -30,7 +30,9 @@ ACCENT_TESTS = (
 
 WHITE_SPACE_TESTS = (
         ("これは 半角スペースです", " "),
-        ("これは	タブ文字です", "	"),
+        ("これは\tタブ文字です", "\t"),
+        ("これは\n改行文字です", "\n"),
+        ("これは\n\t 複数種類の空白文字です", "\n\t "),
         )
 
 @pytest.mark.parametrize('text,wakati', WAKATI_TESTS)

--- a/fugashi/tests/test_basic.py
+++ b/fugashi/tests/test_basic.py
@@ -92,10 +92,11 @@ def test_accent(text, accent):
 def test_clobber():
     # Check that memory isn't clobbered by repeated parse calls
     tagger = Tagger()
-    nodes1 = tagger("a b c d")
+    nodes1 = tagger("a\tb c d")
     nodes2 = tagger("x y z !")
 
     assert "a b c d".split() == [nn.surface for nn in nodes1]
+    assert ["", "\t", " ", " "] == [nn.white_space for nn in nodes1]
 
 @pytest.mark.parametrize("text,space,idx", WHITE_SPACE_TESTS)
 def test_white_space(text, space, idx):

--- a/fugashi/tests/test_basic.py
+++ b/fugashi/tests/test_basic.py
@@ -28,6 +28,11 @@ ACCENT_TESTS = (
         ('稻村に行きました', ['0,2', '*', '0', '*', '*']),
         )
 
+WHITE_SPACE_TESTS = (
+        ("これは 半角スペースです", " "),
+        ("これは	タブ文字です", "	"),
+        )
+
 @pytest.mark.parametrize('text,wakati', WAKATI_TESTS)
 def test_wakati(text, wakati):
     tagger = Tagger('-Owakati')
@@ -86,3 +91,10 @@ def test_clobber():
     nodes2 = tagger("x y z !")
 
     assert "a b c d".split() == [nn.surface for nn in nodes1]
+
+@pytest.mark.parametrize("text,space", WHITE_SPACE_TESTS)
+def test_white_space(text, space):
+    tagger = Tagger()
+    nodes = tagger.parseToNodeList(text)
+
+    assert nodes[2].white_space == space


### PR DESCRIPTION
Currently, `Node.white_space` always returns half-width space `" "` (0x20).

However, it is not desirable behavior in my use case because I want to preserve source white space characters other than `" "` (e.g., `"\t"`) also.

By this PR, the function will return the original white space string.