### PR TITLE
Repair wheel for windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,15 +58,11 @@ jobs:
     - name: Build wheel
       run: |
         python -m build --wheel
+      env:
+        FUGASHI_NO_BUNDLE_DLL: 1
     - name: Repair wheel
-      shell: bash
       run: |
-        VERSION=$(python setup.py --version)
-        python -m wheel unpack --dest dist/temp dist/fugashi-${VERSION}-cp${{ matrix.py-short }}-cp${{ matrix.py-short2 }}-win_amd64.whl
-        unlink dist/temp/fugashi-${VERSION}/fugashi/libmecab.dll
-        python -m wheel pack --dest-dir ./dist ./dist/temp/fugashi-${VERSION}
-        rm --recursive ./dist/temp
-        python -m delvewheel repair --add-path="C:/mecab" ./dist/fugashi-*.whl
+        python -m delvewheel repair --add-path=C:/mecab ./dist/fugashi-*.whl
     - name: Upload Wheel
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,7 +59,13 @@ jobs:
       run: |
         python -m build --wheel
     - name: Repair wheel
+      shell: bash
       run: |
+        VERSION=$(python setup.py --version)
+        python -m wheel unpack --dest dist/temp dist/fugashi-${VERSION}-cp${{ matrix.py-short }}-cp${{ matrix.py-short2 }}-win_amd64.whl
+        unlink dist/temp/fugashi-${VERSION}/fugashi/libmecab.dll
+        python -m wheel pack --dest-dir ./dist ./dist/temp/fugashi-${VERSION}
+        rm --recursive ./dist/temp
         python -m delvewheel repair --add-path="C:/mecab" ./dist/fugashi-*.whl
     - name: Upload Wheel
       uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,7 +53,7 @@ jobs:
         unzip -o "mecab-msvc-x64.zip" -d c:/mecab
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade setuptools wheel pip setuptools-scm delvewheel
+        python -m pip install --upgrade setuptools wheel pip setuptools-scm build delvewheel
         pip install -r requirements.txt
     - name: Build wheel
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,22 +53,25 @@ jobs:
         unzip -o "mecab-msvc-x64.zip" -d c:/mecab
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade setuptools wheel pip setuptools-scm
+        python -m pip install --upgrade setuptools wheel pip setuptools-scm delvewheel
         pip install -r requirements.txt
     - name: Build wheel
       run: |
-        python setup.py bdist_wheel
+        python -m build --wheel
+    - name: Repair wheel
+      run: |
+        python -m delvewheel repair --add-path="C:/mecab" ./dist/fugashi-*.whl
     - name: Upload Wheel
       uses: actions/upload-artifact@v4
       with:
         name: win-wheels-${{ matrix.python-version }}
-        path: dist
+        path: wheelhouse
     - name: Check wheels
       shell: bash
       run: |
         ls -la
         VERSION=$(python setup.py --version)
-        pip install "dist/fugashi-${VERSION}-cp${{ matrix.py-short }}-cp${{ matrix.py-short2 }}-win_amd64.whl"
+        pip install "wheelhouse/fugashi-${VERSION}-cp${{ matrix.py-short }}-cp${{ matrix.py-short2 }}-win_amd64.whl"
     - name: Publish to PyPI if tagged
       if: startsWith(github.ref, 'refs/tags')
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ dmypy.json
 .pyre/
 
 /fugashi/fugashi.c
+/fugashi/libmecab.dll

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -17,7 +17,7 @@ def mecab_config_windows():
     win_mecab_dir = r'C:\mecab'
     win_bin_dir = win_mecab_dir # this is separate from the sdk dir on some installs
     mecab_details = (win_mecab_dir, win_mecab_dir, 'libmecab')
-    data_files = ["{}\\libmecab.dll".format(win_bin_dir)]
+    data_files = ['{}\\libmecab.dll'.format(win_bin_dir)]
     return mecab_details, data_files
 
 def mecab_config_cygwin():

--- a/fugashi_util.py
+++ b/fugashi_util.py
@@ -1,8 +1,7 @@
 import os
 import platform
-import site
 import subprocess
-import glob
+
 
 def mecab_config(com="mecab-config"):
     output = subprocess.check_output([com, "--inc-dir", "--libs-only-L", "--libs-only-l"])
@@ -18,7 +17,7 @@ def mecab_config_windows():
     win_mecab_dir = r'C:\mecab'
     win_bin_dir = win_mecab_dir # this is separate from the sdk dir on some installs
     mecab_details = (win_mecab_dir, win_mecab_dir, 'libmecab')
-    data_files = [("lib\\site-packages\\fugashi\\", ["{}\\libmecab.dll".format(win_bin_dir)])]
+    data_files = ["{}\\libmecab.dll".format(win_bin_dir)]
     return mecab_details, data_files
 
 def mecab_config_cygwin():

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import sys
 
@@ -19,9 +20,15 @@ extra_objects = mecab_config[3].split()
 extra_link_args = mecab_config[4].split()
 
 
+bundle_dll = sys.platform == 'win32' and os.environ.get(
+    'FUGASHI_NO_BUNDLE_DLL', ''
+) not in ['', '0']
+fugashi_package_files = [pathlib.Path(i).name for i in dll_files] if bundle_dll else []
+
+
 class build_ext(_build_ext):
     def run(self):
-        if sys.platform == 'win32':
+        if bundle_dll:
             if self.editable_mode:
                 fugashi_dir = pathlib.Path(__file__).parent / 'fugashi'
             else:
@@ -55,7 +62,7 @@ setup(name='fugashi',
       python_requires='>=3.8',
       ext_modules=[extensions],
       cmdclass={'build_ext': build_ext},
-      package_data={'fugashi': [pathlib.Path(i).name for i in dll_files]},
+      package_data={'fugashi': fugashi_package_files},
       entry_points={
           'console_scripts': [
               'fugashi = fugashi.cli:main',

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,15 @@ extra_objects = mecab_config[3].split()
 extra_link_args = mecab_config[4].split()
 
 
-bundle_dll = sys.platform == 'win32' and os.environ.get(
-    'FUGASHI_NO_BUNDLE_DLL', ''
-) not in ['', '0']
-fugashi_package_files = [pathlib.Path(i).name for i in dll_files] if bundle_dll else []
-
+# Windows DLL related prep.
+# By default the DLL will be bundled on windows, but you can turn it off with
+# an env var.
+bundle_dll = False
+fugashi_package_files = []
+no_bundle_env_var = os.environ.get("FUGASHI_NO_BUNDLE_DLL", "")
+if sys.platform == 'win32' and no_bundle_env_var not in ['', '0']:
+    bundle_dll = True
+    fugashi_package_files = [pathlib.Path(i).name for i in dll_files]
 
 class build_ext(_build_ext):
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extra_link_args = mecab_config[4].split()
 # an env var.
 bundle_dll = False
 fugashi_package_files = []
-no_bundle_env_var = os.environ.get("FUGASHI_NO_BUNDLE_DLL", "")
+no_bundle_env_var = os.environ.get('FUGASHI_NO_BUNDLE_DLL', '')
 if sys.platform == 'win32' and no_bundle_env_var not in ['', '0']:
     bundle_dll = True
     fugashi_package_files = [pathlib.Path(i).name for i in dll_files]

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ extra_link_args = mecab_config[4].split()
 
 class build_ext(_build_ext):
     def run(self):
-        if self.editable_mode and sys.platform == "win32":
-            fugashi_dir = pathlib.Path(__file__).parent / "fugashi"
+        if self.editable_mode and sys.platform == 'win32':
+            fugashi_dir = pathlib.Path(__file__).parent / 'fugashi'
             for i in dll_files:
                 self.copy_file(i, fugashi_dir)
         return super().run()
@@ -51,7 +51,7 @@ setup(name='fugashi',
           ],
       python_requires='>=3.8',
       ext_modules=[extensions],
-      cmdclass={"build_ext": build_ext},
+      cmdclass={'build_ext': build_ext},
       entry_points={
           'console_scripts': [
               'fugashi = fugashi.cli:main',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class build_ext(_build_ext):
             if self.editable_mode:
                 fugashi_dir = pathlib.Path(__file__).parent / 'fugashi'
             else:
-                fugashi_dir = pathlib.Path(self.build_lib) / "fugashi"
+                fugashi_dir = pathlib.Path(self.build_lib) / 'fugashi'
             for i in dll_files:
                 self.copy_file(i, fugashi_dir)
         return super().run()

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,10 @@ if sys.platform == 'win32' and no_bundle_env_var not in ['', '0']:
     fugashi_package_files = [pathlib.Path(i).name for i in dll_files]
 
 class build_ext(_build_ext):
+    """Custom behavior for build_ext.
+
+    This is only run when bundling DLLs on Windows, which requires copying
+    files around."""
     def run(self):
         if bundle_dll:
             if self.editable_mode:

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,11 @@ extra_link_args = mecab_config[4].split()
 
 class build_ext(_build_ext):
     def run(self):
-        if self.editable_mode and sys.platform == 'win32':
-            fugashi_dir = pathlib.Path(__file__).parent / 'fugashi'
+        if sys.platform == 'win32':
+            if self.editable_mode:
+                fugashi_dir = pathlib.Path(__file__).parent / 'fugashi'
+            else:
+                fugashi_dir = pathlib.Path(self.build_lib) / "fugashi"
             for i in dll_files:
                 self.copy_file(i, fugashi_dir)
         return super().run()
@@ -52,6 +55,7 @@ setup(name='fugashi',
       python_requires='>=3.8',
       ext_modules=[extensions],
       cmdclass={'build_ext': build_ext},
+      package_data={'fugashi': [pathlib.Path(i).name for i in dll_files]},
       entry_points={
           'console_scripts': [
               'fugashi = fugashi.cli:main',


### PR DESCRIPTION
Repair the Windows wheel will solve the issue.

- fix #33

With this change, there will be no missing dlls as long as you install the released wheel.

This fix has the following issues on Windows:
- If you install from source code, you must do `Editable Installs`.
`pip install -e .`
- If this is not possible (e.g. using a tarball or URL) the dll will not be collected and cannot be executed.
`pip install git+https://github.com/polm/fugashi.git`