### PR TITLE
build: only include fugashi package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ funding = "https://github.com/sponsors/polm"
 include-package-data = false
 
 [tool.setuptools.packages.find]
+include = ["fugashi*"]
 exclude = ["fugashi.tests*"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
In the CI build workflow, Mecab is cloned into the fugashi repo: https://github.com/polm/fugashi/blob/60594f930d49bcfb1d4d9c72d310bfa3301444d9/.github/workflows/manylinux1.yml#L16

After the change to `pyproject.toml` layout in #109, the fugashi 1.50 sdist and wheels now also include Python code from the Mecab repo (https://github.com/taku910/mecab/tree/master/mecab/python) as a `mecab` package. This is not needed and can lead to conflicts. For example, Coqui TTS also depends on `python-mecab-ko`, which is imported as `mecab` as well.

This change ensures that only the `fugashi` package itself is included in the build output.